### PR TITLE
Fix and improve action buttons.

### DIFF
--- a/src/notificationwidgets.h
+++ b/src/notificationwidgets.h
@@ -65,7 +65,7 @@ signals:
 
 protected:
     QString m_defaultAction;
-    QHash<QString,QString> m_actionMap;
+    QList<QPair<QString/*action key*/, QString/*action value*/>> m_actions;
 };
 
 class NotificationActionsButtonsWidget : public NotificationActionsWidget


### PR DESCRIPTION
Qt now adds an accelerator which makes `text()` return `&foo` instead of
just `foo` after `setText("foo")` has been issued. This broke the
association of button's text to the original action key.

A better way of identifying which action key is bound to which button is
to store the key in the button's objectName property.

Finally, this removes the use of a hash to store actions so that their
order is preserved.