### PR TITLE
Don't force rich text formatting on app, summary and body labels.

### DIFF
--- a/src/notification.ui
+++ b/src/notification.ui
@@ -81,9 +81,6 @@
        <property name="text">
         <string notr="true">TextLabel</string>
        </property>
-       <property name="textFormat">
-        <enum>Qt::RichText</enum>
-       </property>
        <property name="wordWrap">
         <bool>false</bool>
        </property>
@@ -93,9 +90,6 @@
       <widget class="QLabel" name="summaryLabel">
        <property name="text">
         <string notr="true">TextLabel</string>
-       </property>
-       <property name="textFormat">
-        <enum>Qt::RichText</enum>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
@@ -112,9 +106,6 @@
        </property>
        <property name="text">
         <string notr="true">TextLabel</string>
-       </property>
-       <property name="textFormat">
-        <enum>Qt::RichText</enum>
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>


### PR DESCRIPTION
QLabel will not propagate mouseReleaseEvent when clicking on text when
rich text is enabled. This means that clicking the notification does
nothing while the indended behaviour is to execute the default action.

This workaround disables rich text by default, which makes mouseReleaseEvent
work again. Rich text can still be used as QLabel uses AutoText by default.

This also means that if a text contains rich text, then clicking on it will
not have the expected behaviour, but it's still better than never having
the intended behaviour !

I reported the bug to Qt (assuming it's a bug) : https://bugreports.qt.io/browse/QTBUG-49025