### PR TITLE
lxqt-config-notificationd.desktop.in: fix QA errors

### DIFF
--- a/config/lxqt-config-notificationd.desktop.in
+++ b/config/lxqt-config-notificationd.desktop.in
@@ -5,7 +5,7 @@ GenericName=LXQt Notification Settings
 Comment=Configure desktop notifications
 Exec=lxqt-config-notificationd
 Icon=preferences-desktop-theme
-Categories=Settings;DesktopSettings;Qt;LXQt;
-OnlyShowIn=LXQt;
+X-Categories=Settings;DesktopSettings;Qt;LXQt;
+X-OnlyShowIn=LXQt;
 
 #TRANSLATIONS_DIR=translations


### PR DESCRIPTION
Keys extending the standard format should start with "X-"
as per the desktop entry spec.

Signed-off-by: Ioan-Adrian Ratiu <adi@adirat.com>