### PR TITLE
make sure the notification area is updated if the screen layout changes

### DIFF
--- a/src/notificationarea.cpp
+++ b/src/notificationarea.cpp
@@ -58,7 +58,9 @@ NotificationArea::NotificationArea(QWidget *parent)
     connect(m_layout, &NotificationLayout::allNotificationsClosed, this, &NotificationArea::close);
     connect(m_layout, &NotificationLayout::notificationAvailable, this, &NotificationArea::show);
     connect(m_layout, &NotificationLayout::heightChanged, this, &NotificationArea::setHeight);
-    connect(qApp->desktop(), &QDesktopWidget::workAreaResized, this, &NotificationArea::setHeight);
+    // Make sure we update the height whenever the screen geometry changes. Make sure setHeight actually takes this height into account.
+    connect(qApp->desktop(), &QDesktopWidget::workAreaResized, [this](int screen) { setHeight(-2); });
+    connect(qApp->desktop(), &QDesktopWidget::screenCountChanged, [this](int screen) { setHeight(-2); });
 }
 
 void NotificationArea::setHeight(int contentHeight)
@@ -81,7 +83,7 @@ void NotificationArea::setHeight(int contentHeight)
     workArea -= QMargins(m_spacing, m_spacing, m_spacing, m_spacing);
     QRect notif_rect = workArea.normalized();
     notif_rect.setWidth(width());
-    if (notif_rect.height() > contentHeight)
+    if (notif_rect.height() > contentHeight && contentHeight >= -1) // don't cap the height if this comes from a screen geometry change
         notif_rect.setHeight(contentHeight);
 
     // no move needed for "top-left"


### PR DESCRIPTION
Previously, following the steps described in https://github.com/lxde/lxqt/issues/990, notifications would still show up at the "old" position after the small screen has been removed.

However, I can't say that I understood the magic values `0` and `-1` for `contentheight` in `setHeight`, nor did I understand why there is a check that makes sure that the `notif_rect` is no larger than the `contentHeight`. I had to disable this check for updates triggered by `QDesktopWidget` -- otherwise, that check would prevent the notification area from growing, so notifications would still show up at the wrong place.

I would not find any place that calls `setHeight(-1)` or `setHeight(0)`. Some comments for why `setHeight` does these rather arbitrary things that it does would be helpful :)
