### PR TITLE
Fix spanish translation and fix typo in es_VE

### DIFF
--- a/config/translations/lxqt-config-notificationd_es.desktop
+++ b/config/translations/lxqt-config-notificationd_es.desktop
@@ -1,4 +1,4 @@
 # Translations
-GenericName[es]=Administrador de tareas
-Name[es]=Configuración de sesiones LXQt
-Comment[es]=Configure las notificacionde de freedesktop en el escritorio LXQt
+GenericName[es]=Notificaciones de Escritorio
+Name[es]=Configuración de Notificaciones de LXQt
+Comment[es]=Configure las notificaciones de freedesktop en el escritorio LXQt

--- a/config/translations/lxqt-config-notificationd_es_VE.desktop
+++ b/config/translations/lxqt-config-notificationd_es_VE.desktop
@@ -1,4 +1,4 @@
 # Translations
-GenericName[es_VE]=Configuracion de notificaciones de Escritorio LXQt
-Name[es_VE]=Configuracion de notificaciones de Escritorio LXQt
+GenericName[es_VE]=Configuración de notificaciones de Escritorio LXQt
+Name[es_VE]=Configuración de notificaciones de Escritorio LXQt
 Comment[es_VE]=Configura las notificacones en el Escritoro LXQt


### PR DESCRIPTION
In spanish, the notification settings desktop file has the same translation that session settings and it has a incorrect generic name